### PR TITLE
enable translations

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,6 +41,7 @@ if [[ ${CONDA_BUILD_CROSS_COMPILATION:-0} == 1 ]]; then
 fi
 
 cmake -S . -B build \
+    -DENABLE_TRANSLATIONS=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DUSE_BUNDLED=OFF \
     -DLIBUV_LIBRARY="${PREFIX}/lib/libuv${SHLIB_EXT}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 10413265a915133f8a853dc757571334ada6e4f0aa15f4c4cc8cc48341186ca2
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
@anjos noticed that as of 0.11.0, translations are disabled by default and must be enabled with `-DENABLE_TRANSLATIONS=ON`, so we'll increment the build number here to add this.