### PR TITLE
Add build config for linux-ppc64le

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+libiconv:
+- '1'
+libutf8proc:
+- '2.10'
+msgpack_c:
+- '6'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- vs2019
+- vs2022
 c_stdlib:
 - vs
 channel_sources:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19280&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nvim-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19280&branchName=main">

--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,7 @@ build_platform:
   osx_arm64: osx_64
 provider:
   linux_aarch64: azure
+  linux_ppc64le: azure
 conda_build:
   error_overlinking: true
 conda_build_tool: rattler-build


### PR DESCRIPTION
This pull request adds support for building packages on the `linux_ppc64le` platform using Azure as the provider in the `conda-forge.yml` configuration file.

Platform support update:

* [`conda-forge.yml`](diffhunk://#diff-478786365dd93f740eb520c2faa03d7a0623273663b75472272c8ef94297bbe2R7): Added `linux_ppc64le` to the `provider` section, specifying Azure as the build provider.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
