### PR TITLE
Set `global-ignore-conda-prefix`

### DIFF
--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -17,6 +17,11 @@ cmake -S . -B build -G Ninja ^
 cmake --build build --parallel %CPU_COUNT% || goto :error
 cmake --install build --parallel %CPU_COUNT% || goto :error
 
+:: Tell `pixi global` to not set CONDA_PREFIX during activation
+:: https://pixi.sh/dev/global_tools/introduction/#opt-out-of-conda_prefix
+if not exist "%PREFIX%\\etc\\pixi" mkdir "%PREFIX%\\etc\\pixi\\nvim"
+type nul > "%PREFIX%\\etc\\pixi\\nvim\\global-ignore-conda-prefix"
+
 goto :EOF
 
 :error

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -51,3 +51,8 @@ cmake -S . -B build \
     ${CMAKE_ARGS}
 cmake --build build --parallel "${CPU_COUNT}"
 cmake --install build --parallel "${CPU_COUNT}"
+
+# Tell `pixi global` to not set CONDA_PREFIX during activation
+# https://pixi.sh/dev/global_tools/introduction/#opt-out-of-conda_prefix
+mkdir -p "${PREFIX}/etc/pixi/nvim"
+touch "${PREFIX}/etc/pixi/nvim/global-ignore-conda-prefix"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 83cf9543bedab8bec8c11cd50ccd9a4bf1570420a914b9a28f83ad100ca6d524
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

If `nvim` is installed using `pixi global` it is placed in its own environment with `CONDA_PREFIX` set to this environment. This is problematic for tools like language servers, e.g. `ty` for python, which read `CONDA_PREFIX` to find the location of installed python packages. Recently pixi added an option to not set `CONDA_PREFIX` for specific packages when installed using `pixi global`, see https://pixi.sh/dev/global_tools/introduction/#install-packages-for-a-different-platform. Here this is enabled for neovim.
