### PR TITLE
depend on gettext on osx

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,6 +44,8 @@ requirements:
       then: libiconv
     - if: osx or win
       then: libintl-devel
+    - if osx:
+      then: gettext
   run:
     - luajit-openresty
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 41898a5073631bc8fd9ac43476b811c05fb3b88ffb043d4fbb9e75e478457336
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,7 +44,7 @@ requirements:
       then: libiconv
     - if: osx or win
       then: libintl-devel
-    - if osx:
+    - if: osx
       then: gettext
   run:
     - luajit-openresty


### PR DESCRIPTION
With some advice from @pavelzw creating a PR to fix the following error when running on a fresh copy of Mac OS X:

```
dyld[20454]: Library not loaded: /opt/homebrew/opt/gettext/lib/libintl.8.dylib
  Referenced from: <55F4030F-9A6C-31F0-854E-94C2E195E654> /Users/ben/.pixi/envs/nvim/bin/nvim
  Reason: tried: '/opt/homebrew/opt/gettext/lib/libintl.8.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/gettext/lib/libintl.8.dylib' (no such file), '/opt/homebrew/opt/gettext/lib/libintl.8.dylib' (no such file), '/usr/local/lib/libintl.8.dylib' (no such file), '/usr/lib/libintl.8.dylib' (no such file, not in dyld cache)
```

I've built and run this locally on hot and fresh macbook neo with no homebrew installed.